### PR TITLE
Fix windows extract

### DIFF
--- a/lib/build_dot_zig/zig_installer.ex
+++ b/lib/build_dot_zig/zig_installer.ex
@@ -73,7 +73,12 @@ defmodule BuildDotZig.ZigInstaller do
   end
 
   defp extract_zip(archive_filename) do
-    {_, 0} = System.cmd("unzip", [archive_filename])
+    # windows needs a charlist path
+    archive_filename_charlist =
+      archive_filename
+      |> to_charlist()
+
+    {:ok, _} = :zip.unzip(archive_filename_charlist)
     Path.basename(archive_filename, ".zip")
   end
 


### PR DESCRIPTION
```** 
(ErlangError) Erlang error: :enoent
(elixir 1.15.7) lib/system.ex:1092: System.cmd("unzip", ["zig-windows-x86_64-0.11.0.zip"], [])
(build_dot_zig 0.4.2) lib/build_dot_zig/zig_installer.ex:76: BuildDotZig.ZigInstaller.extract_zip/1
(build_dot_zig 0.4.2) lib/build_dot_zig/zig_installer.ex:59: BuildDotZig.ZigInstaller.extract_archive!/2
(build_dot_zig 0.4.2) lib/build_dot_zig/compiler.ex:244: BuildDotZig.Compiler.ensure_downloaded_zig!/1
(build_dot_zig 0.4.2) lib/build_dot_zig/compiler.ex:36: BuildDotZig.Compiler.build/1
(build_dot_zig 0.4.2) lib/build_dot_zig/compiler.ex:11: BuildDotZig.Compiler.compile/0
(mix 1.15.7) lib/mix/task.ex:455: anonymous fn/3 in Mix.Task.run_task/5
```
On windows unzipping fails for me. This fixes it. Not sure if it is okay that way or maybe better add some os checking and change to the charlist already higher in the code.